### PR TITLE
feat(makefile): add cross-platform 'make open' to launch Jupyter via browser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   jupyter_service:
     build: .


### PR DESCRIPTION

- Resolves mapped container port dynamically
- Extracts token from logs (if available)
- Supports Linux/macOS/Windows (xdg-open, open, powershell, rundll32)